### PR TITLE
Link en pantalla de inicio y nombre menu

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,4 @@
-Bienvenidos, consulta en el menú lateral los documentos disponibles.
+Bienvenidos a la web de documentación de la asociación AVAST 
+
+# Matriculación en talleres
+[Ayuda para la matriculación en talleres](./asignacion)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,4 +6,4 @@ theme:
 
 nav:
   - Inicio: index.md
-  - Asignación de talleres: asignacion.md
+  - Matriculación en talleres: asignacion.md


### PR DESCRIPTION
1. Cambiado el título de la documentación para matrícula.

2. Añado un enlace para la opción de menú en la página de inicio.
El motivo es que cuando entras en móvil veo un poco más farragoso de lo necesario encontrar el enlace correcto.
- En móvil no hay menú lateral, es un menú de esos tipo hamburguesa que hay que desplegar
- En la página hay más enlaces presentes que pueden confundir (publicidad, el readthedocs, el botón de Next)

Si no abrimos las docs directamente de matrícula, veo más fácil poner la lista de enlaces en la home



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the homepage introduction to reference the AVAST association's documentation website.
  - Added a new section on "Matriculación en talleres" with a helpful link for workshop enrollment assistance.
  - Updated the navigation menu label from "Asignación de talleres" to "Matriculación en talleres" for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->